### PR TITLE
Refactor code to use 2013 when Medicare data is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.pyc
 *.csv
+*.xlsx
+*.db

--- a/nppes_medicare/database.py
+++ b/nppes_medicare/database.py
@@ -1,13 +1,6 @@
 import sqlite3
 import pandas as pd
 
-# Define the columns to keep for the main table
-COLUMNS_TO_KEEP = [
-    'npi', 'entity', 'replacement_npi', 'ein', 'porgname', 'pcredential',
-    'pmailstatename', 'pmailzip', 'pmailcountry', 'plocstatename', 'ploczip', 
-    'ploccountry', 'penumdate', 'lastupdate', 'npideactreason', 'npideactdate', 
-    'npireactdate', 'pgender'
-]
 
 class NppesDatabase:
     def __init__(self, db_file):
@@ -30,18 +23,15 @@ class NppesDatabase:
             ein TEXT,
             porgname TEXT,
             pcredential TEXT,
-            pmailstatename TEXT,
-            pmailzip TEXT,
-            pmailcountry TEXT,
             plocstatename TEXT,
             ploczip TEXT,
-            ploccountry TEXT,
             penumdate TEXT,
             lastupdate TEXT,
             npideactreason TEXT,
             npideactdate TEXT,
             npireactdate TEXT,
-            pgender TEXT
+            pgender TEXT,
+            ptaxcode TEXT
         );
         """
         with self.conn:
@@ -50,25 +40,24 @@ class NppesDatabase:
 
     def _create_taxonomy_table(self):
         create_table_sql = """
-        CREATE TABLE IF NOT EXISTS nppes_taxonomy (
-            npi TEXT,
+        CREATE TABLE IF NOT EXISTS taxonomy (
             ptaxcode TEXT,
             physician INTEGER,
-            PRIMARY KEY (npi, ptaxcode),
-            FOREIGN KEY (npi) REFERENCES nppes (npi)
+            student INTEGER,
+            np_type TEXT,
+            np INTEGER,
+            Type, TEXT,
+            PRIMARY KEY (ptaxcode)
         );
         """
         with self.conn:
             self.conn.execute(create_table_sql)
-        print("Created table nppes_taxonomy")
+        print("Created table taxonomy")
 
     def _create_medicare_table(self):
         create_table_sql = """
         CREATE TABLE IF NOT EXISTS medicare (
-            rndrng_npi TEXT PRIMARY KEY,
-            rndrng_prvdr_ent_cd TEXT,
-            tot_benes INTEGER,
-            rndrng_prvdr_mdcr_prtcptg_ind TEXT,
+            npi TEXT PRIMARY KEY,
             mdcr_provider INTEGER
         );
         """
@@ -76,13 +65,7 @@ class NppesDatabase:
             self.conn.execute(create_table_sql)
         print("Created table medicare")
 
-    # def subset_and_insert_data(self, df, n=100):
-    #     subset_df = df.sample(n=n, random_state=1)
-    #     self.insert_data(subset_df)
-    #     print(f"Inserted a subset of {len(subset_df)} rows into the database")
-
     def insert_main_data(self, df):
-        subset_df = df.sample(n=100000, random_state=1)
         df.to_sql('nppes', self.conn, if_exists='append', index=False)
         print("Inserted data into nppes")
 

--- a/nppes_medicare/global_variables.py
+++ b/nppes_medicare/global_variables.py
@@ -1,0 +1,28 @@
+# global_variables.py
+
+# Define the columns to keep for the main table
+MAIN_TABLE_COLS_MAPPING = {
+    "NPI": "npi",
+    "Entity Type Code": "entity",
+    "Replacement NPI": "replacement_npi",
+    "Employer Identification Number (EIN)": "ein",
+    "Provider Organization Name (Legal Business Name)": "porgname",
+    "Provider Credential Text": "pcredential",
+    "Provider Business Practice Location Address State Name": "plocstatename",
+    "Provider Business Practice Location Address Postal Code": "ploczip",
+    "Provider Enumeration Date": "penumdate",
+    "Last Update Date": "lastupdate",
+    "NPI Deactivation Reason Code": "npideactreason",
+    "NPI Deactivation Date": "npideactdate",
+    "NPI Reactivation Date": "npireactdate",
+    "Provider Gender Code": "pgender",
+    "Healthcare Provider Taxonomy Code_1": "ptaxcode"
+}
+
+COLS_TO_KEEP = [
+    'npi', 'entity', 'replacement_npi', 'ein', 'porgname', 'pcredential',
+    'plocstatename', 'ploczip',
+    'penumdate', 'lastupdate', 'npideactreason', 'npideactdate', 
+    'npireactdate', 'pgender', 'ptaxcode'
+]
+

--- a/nppes_medicare/utils.py
+++ b/nppes_medicare/utils.py
@@ -1,3 +1,4 @@
+from global_variables import MAIN_TABLE_COLS_MAPPING
 import pandas as pd
 import requests
 import os
@@ -14,37 +15,85 @@ def download_file(url, dest_folder):
     return local_filename
 
 
-def load_csv_to_dataframe(csv_file, encoding='utf-8'):
+def load_csv_to_dataframe(csv_file, encoding='utf-8', test=False):
     encodings = [encoding, 'latin1', 'cp1252']
     for encoding in encodings:
         try:
-            df = pd.read_csv(csv_file, encoding=encoding)
+            if test:
+                nrows = 100000
+            else:
+                nrows = 1e10
+            df = pd.read_csv(csv_file, nrows=nrows, encoding=encoding, low_memory=False)
             print(f"Loaded {len(df)} rows from {csv_file} with encoding {encoding}")
             return df
         except UnicodeDecodeError:
             print(f"Failed to load {csv_file} with encoding {encoding}")
     raise UnicodeDecodeError("All encodings failed to decode the CSV file.")
 
+
 def process_main_data(df, columns_to_keep):
-    df = df[df['entity'] == 1]
+    df = df[df['Entity Type Code'] == 1]
+    # map columns with MAIN_TABLE_COLS_MAPPING
+    df = df.rename(columns=MAIN_TABLE_COLS_MAPPING)
     df = df[columns_to_keep]
     df.drop_duplicates(subset=['npi'], inplace=True)
     return df
 
-def process_taxonomy_data(df, taxonomy_df):
-    if 'ptaxcode1' in df.columns:
-        temp_df = df[['npi', 'ptaxcode1']].dropna()
-        temp_df.rename(columns={'ptaxcode1': 'ptaxcode'}, inplace=True)
-        temp_df = temp_df.merge(taxonomy_df[['Code', 'Type']], left_on='ptaxcode', right_on='Code', how='left')
-        temp_df['physician'] = temp_df['Type'].apply(lambda x: 1 if 'Allopathic & Osteopathic Physicians' in str(x) else 0)
-        temp_df.drop(columns=['Code', 'Type'], inplace=True)
-        return temp_df.drop_duplicates()
-    return pd.DataFrame(columns=['npi', 'ptaxcode', 'physician'])
+
+def assign_np_type(df):
+    # Define mapping for tax codes to np_type
+    np_type_mapping = {
+        "363L00000X": "Nursing Practice",
+        "363LA2100X": "Acute Care",
+        "363LF0000X": "Family Practice",
+        "363LG0600X": "Geriatric",
+        "363LP2300X": "Primary Care",
+        "363LP0808X": "Psychiatric"
+    }
+
+    # Apply the mapping
+    df['np_type'] = df['ptaxcode'].map(np_type_mapping)
+
+    # Define additional categories using .isin()
+    pediatric_codes = ["363LP0200X", "363LS0200X"]
+    maternal_neonatal_codes = ["363LX0001X", "363LN0000X", "363LP1700X"]
+    adult_health_codes = ["363LA2200X", "363LC1500X", "363LX0106X", "363LW0102X"]
+    critical_care_codes = ["363LC0200X", "363LN0005X", "363LP0222X"]
+
+    # Update np_type based on these lists
+    df.loc[df['ptaxcode'].isin(pediatric_codes), 'np_type'] = "Pediatric"
+    df.loc[df['ptaxcode'].isin(maternal_neonatal_codes), 'np_type'] = "Maternal/Neonatal"
+    df.loc[df['ptaxcode'].isin(adult_health_codes), 'np_type'] = "Adult Health"
+    df.loc[df['ptaxcode'].isin(critical_care_codes), 'np_type'] = "Critical Care"
+    df['np'] = df['np_type'].notnull().astype(int)
+
+    return df
+
+
+def process_taxonomy_data(taxonomy_df):
+    df = taxonomy_df[['Code', 'Type']].copy()
+    df = df.drop(0) # copyright
+
+    # Add physician and student indicators
+    df['physician'] = df['Type'].apply(lambda x: 1 if 'Allopathic & Osteopathic Physicians' in str(x) else 0)
+    df['student'] = df['Code'].apply(lambda x: 1 if x == "390200000X" else 0)
+    df.rename(columns={'Code': 'ptaxcode'}, inplace=True)
+
+    # Assign taxonomy codes to nurse practitioner types
+    df = assign_np_type(df)
+
+    return df
+
 
 def process_medicare_data(df):
-    df = df[['rndrng_npi', 'rndrng_prvdr_ent_cd', 'tot_benes', 'rndrng_prvdr_mdcr_prtcptg_ind']]
-    df = df[df['rndrng_prvdr_ent_cd'] == "I"]
-    df['mdcr_provider'] = df['rndrng_prvdr_mdcr_prtcptg_ind'] == "Y"
-    df['mdcr_provider'] = df['mdcr_provider'].astype(int)
+    df.columns = df.columns.str.lower()
+    
+    # Individuals only
+    df = df[df['rndrng_prvdr_ent_cd'] == "I"].copy()
+    df['mdcr_provider'] = (df['rndrng_prvdr_mdcr_prtcptg_ind'] == "Y").astype(int)
+    
     df.drop_duplicates(subset=['rndrng_npi'], inplace=True)
+    df = df[['rndrng_npi', 'mdcr_provider']].copy()
+    df.rename(columns={'rndrng_npi': 'npi'}, inplace=True)
+    
     return df


### PR DESCRIPTION
<!---
Please write your PR name in the present imperative tense. Examples of present imperative tense are:
"Fix issue in the dispatcher where…", "Improve our handling of…", etc."

For more information on Pull Requests, you can reference here:
https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute
-->
## Describe your changes

This PR makes updates the data build to start in 2013 rather than the 2007 file. The public Medicare data file with the provider's medicare acceptance status was first published then. The PR also updates how taxonomy codes are encoded (physician, student, and NP designations for now). Closes #10.

## Non-obvious technical information

Some of the pandas code was written to avoid the warning about operating on a copy of a data frame and some clean up may be warranted or otherwise streamlining the process for better memory management. Although the datasets are relatively small.